### PR TITLE
Simplify configuration

### DIFF
--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -43,6 +43,7 @@ DAILY_RATE_LIMIT=86400
 REQUIRE_SECURE=false
 DEBUG=false
 SYSTEM_PROMPT_PATH=./
+SYSTEM_PROMPT=
 
 # Temperature
 # Controls the randomness of the model's outputs.

--- a/services/api/src/core/document_manager.py
+++ b/services/api/src/core/document_manager.py
@@ -36,8 +36,6 @@ class DocumentStoreManager:
             if (
                 self.es_basic_auth_user
                 and self.es_basic_auth_password
-                and isinstance(self.es_basic_auth_user, str)
-                and isinstance(self.es_basic_auth_password, str)
                 and self.es_basic_auth_user.strip()
                 and self.es_basic_auth_password.strip()
             ):

--- a/services/api/src/main.py
+++ b/services/api/src/main.py
@@ -70,8 +70,20 @@ if not API_KEY:
 
 
 def load_systemprompt(base_path: str) -> str:
-    file = Path(base_path) / ".systemprompt"
     default_prompt = ""
+
+    # Use environment variable if available
+    env_var_name = "SYSTEM_PROMPT"
+    env_prompt = os.getenv(env_var_name)
+    if env_prompt is not None:
+        content = env_prompt.strip()
+        logger.info(
+            f"Using system prompt from '{env_var_name}' environment variable; content: '{content}'"
+        )
+        return content
+
+    # Try reading from file
+    file = Path(base_path) / ".systemprompt"
 
     if not file.exists():
         logger.info("No .systemprompt file found. Using default prompt.")

--- a/tools/embed/.env.example
+++ b/tools/embed/.env.example
@@ -12,6 +12,8 @@ HF_API_KEY=your-huggingface-api-key
 # Elastic Search
 ES_URL=http://elasticsearch:9200
 ES_INDEX=default
+ES_BASIC_AUTH_USERNAME=
+ES_BASIC_AUTH_PASSWORD=
 
 # Embedding
 EMBEDDING_MODEL_NAME=snowflake-arctic-embed2

--- a/tools/embed/src/cli.py
+++ b/tools/embed/src/cli.py
@@ -134,6 +134,20 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--es-basic-auth-user",
+        type=str,
+        default=os.getenv("ES_BASIC_AUTH_USERNAME", ""),
+        help="Username for the Elasticsearch service authentication",
+    )
+
+    parser.add_argument(
+        "--es-basic-auth-password",
+        type=str,
+        default=os.getenv("ES_BASIC_AUTH_PASSWORD", ""),
+        help="Password for the Elasticsearch service authentication",
+    )
+
+    parser.add_argument(
         "--ollama-url",
         type=str,
         default=os.getenv("OLLAMA_URL", "http://localhost:11434"),

--- a/tools/embed/src/main.py
+++ b/tools/embed/src/main.py
@@ -83,9 +83,11 @@ def main():
         logger.info("Initializing RAG Embedder")
         embedder = RAGEmbedder(
             provider_name=args.provider,
+            ollama_url=args.ollama_url,
             es_url=args.es_url,
             es_index=args.es_index,
-            ollama_url=args.ollama_url,
+            es_basic_auth_user=args.es_basic_auth_user,
+            es_basic_auth_password=args.es_basic_auth_password,
             embedding_model=args.embedding_model,
         )
         logger.debug("RAG Embedder initialized successfully")


### PR DESCRIPTION
Bring back the `SYSTEM_PROMPT` for faster and more flexible testing and deployment. Also implement Elasticsearch auth into embedder tool.
