### PR TITLE
Fully reflect the Ollama api 

### DIFF
--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -28,6 +28,12 @@ IGNORE_MODEL_REQUEST=false
 # - /api/generate
 ENABLE_OLLAMA_PROXY=true
 
+# Enabling Chipper RAG bypass will route chat messages directly to the Ollama instance
+# without applying any RAG embedding steps. This can be useful for debugging but goes
+# against the intended purpose of this project. It can also be used to add an API key
+# to your Ollama instance, though this is not recommended.
+BYPASS_OLLAMA_RAG=false
+
 # Embedding
 EMBEDDING_MODEL_NAME=snowflake-arctic-embed2
 HF_EMBEDDING_MODEL_NAME=sentence-transformers/all-mpnet-base-v2

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -20,6 +20,14 @@ ALLOW_MODEL_PARAMETER_CHANGE=true
 # Ollama clients and HuggingFace by using the API default model instead.
 IGNORE_MODEL_REQUEST=false
 
+# Enables proxying of non-RAG Ollama API endpoints directly to the Ollama instance.
+# If API key authentication is enabled, requests must be authenticated accordingly.
+# This includes endpoints such as:
+# - /api/tags
+# - /api/pull
+# - /api/generate
+ENABLE_OLLAMA_PROXY=true
+
 # Embedding
 EMBEDDING_MODEL_NAME=snowflake-arctic-embed2
 HF_EMBEDDING_MODEL_NAME=sentence-transformers/all-mpnet-base-v2

--- a/services/api/src/api/config.py
+++ b/services/api/src/api/config.py
@@ -35,6 +35,7 @@ ALLOW_MODEL_PARAMETER_CHANGE = (
 )
 IGNORE_MODEL_REQUEST = os.getenv("IGNORE_MODEL_REQUEST", "true").lower() == "true"
 ENABLE_OLLAMA_PROXY = os.getenv("ENABLE_OLLAMA_PROXY", "true").lower() == "true"
+BYPASS_OLLAMA_RAG = os.getenv("BYPASS_OLLAMA_RAG", "false").lower() == "true"
 
 DEBUG = os.getenv("DEBUG", "true").lower() == "true"
 

--- a/services/api/src/api/config.py
+++ b/services/api/src/api/config.py
@@ -34,6 +34,8 @@ ALLOW_MODEL_PARAMETER_CHANGE = (
     os.getenv("ALLOW_MODEL_PARAMETER_CHANGE", "true").lower() == "true"
 )
 IGNORE_MODEL_REQUEST = os.getenv("IGNORE_MODEL_REQUEST", "true").lower() == "true"
+ENABLE_OLLAMA_PROXY = os.getenv("ENABLE_OLLAMA_PROXY", "true").lower() == "true"
+
 DEBUG = os.getenv("DEBUG", "true").lower() == "true"
 
 # Rate limiting configuration

--- a/services/api/src/api/middleware.py
+++ b/services/api/src/api/middleware.py
@@ -78,7 +78,7 @@ def setup_security_middleware(app):
 def setup_request_logging_middleware(app):
     @app.before_request
     def log_request_info():
-        if request.path == "/health":
+        if request.path == "/" or request.path == "/health":
             return
 
         log_data = {
@@ -89,7 +89,7 @@ def setup_request_logging_middleware(app):
             "request_id": request.headers.get("X-Request-ID"),
         }
 
-        logger.info("Incoming request", extra=log_data)
+        logger.debug("Incoming request", extra=log_data)
 
 
 def init_middleware(app):

--- a/services/api/src/api/ollama_proxy.py
+++ b/services/api/src/api/ollama_proxy.py
@@ -15,6 +15,7 @@ class OllamaProxy:
 
     This class provides methods for all Ollama API endpoints, handling both streaming
     and non-streaming responses, and managing various model operations.
+    Ref: https://github.com/ollama/ollama/blob/main/docs/api.md
     """
 
     def __init__(self, base_url: Optional[str] = None):
@@ -101,6 +102,10 @@ class OllamaProxy:
     def generate(self) -> Response:
         """Generate a completion for a given prompt."""
         return self._proxy_request("/api/generate", "POST", stream=True)
+
+    def chat(self) -> Response:
+        """Generate the next message in a chat conversation."""
+        return self._proxy_request("/api/chat", "POST", stream=True)
 
     def embeddings(self) -> Response:
         """Generate embeddings (legacy endpoint)."""

--- a/services/api/src/api/ollama_proxy.py
+++ b/services/api/src/api/ollama_proxy.py
@@ -10,25 +10,49 @@ logger = logging.getLogger(__name__)
 
 
 class OllamaProxy:
+    """
+    A proxy class for interacting with the Ollama API.
+
+    This class provides methods for all Ollama API endpoints, handling both streaming
+    and non-streaming responses, and managing various model operations.
+    """
+
     def __init__(self, base_url: Optional[str] = None):
+        """
+        Initialize the OllamaProxy with a base URL.
+
+        Args:
+            base_url: The base URL for the Ollama API. Defaults to environment variable
+                     OLLAMA_URL or 'http://localhost:11434'
+        """
         self.base_url = base_url or os.getenv("OLLAMA_URL", "http://localhost:11434")
 
-    def _proxy_request(self, path: str, method: str = "GET", stream: bool = False):
+    def _proxy_request(
+        self, path: str, method: str = "GET", stream: bool = False
+    ) -> Response:
+        """
+        Make a proxied request to the Ollama API.
+
+        Args:
+            path: The API endpoint path
+            method: The HTTP method to use
+            stream: Whether to stream the response
+
+        Returns:
+            A Flask Response object
+        """
         url = f"{self.base_url}{path}"
         headers = {
-            k: v for k, v in request.headers.items()
-            if k.lower() not in ['host', 'transfer-encoding']
+            k: v
+            for k, v in request.headers.items()
+            if k.lower() not in ["host", "transfer-encoding"]
         }
 
         data = request.get_data() if method != "GET" else None
 
         try:
             response = requests.request(
-                method=method,
-                url=url,
-                headers=headers,
-                data=data,
-                stream=stream
+                method=method, url=url, headers=headers, data=data, stream=stream
             )
 
             if stream:
@@ -38,12 +62,12 @@ class OllamaProxy:
         except Exception as e:
             logger.error(f"Error proxying request to Ollama: {str(e)}")
             return Response(
-                json.dumps({"error": str(e)}),
-                status=500,
-                mimetype="application/json"
+                json.dumps({"error": str(e)}), status=500, mimetype="application/json"
             )
 
-    def _handle_streaming_response(self, response):
+    def _handle_streaming_response(self, response: requests.Response) -> Response:
+        """Handle streaming responses from the Ollama API."""
+
         def generate():
             try:
                 for chunk in response.iter_content(chunk_size=None):
@@ -60,23 +84,75 @@ class OllamaProxy:
         return Response(
             stream_with_context(generate()),
             status=response.status_code,
-            headers=response_headers
+            headers=response_headers,
         )
 
-    def _handle_standard_response(self, response):
+    def _handle_standard_response(self, response: requests.Response) -> Response:
+        """Handle non-streaming responses from the Ollama API."""
         return Response(
             response.content,
             status=response.status_code,
             headers={
                 "Content-Type": response.headers.get("Content-Type", "application/json")
-            }
+            },
         )
 
-    def generate(self):
+    # Generation endpoints
+    def generate(self) -> Response:
+        """Generate a completion for a given prompt."""
         return self._proxy_request("/api/generate", "POST", stream=True)
 
-    def tags(self):
+    def embeddings(self) -> Response:
+        """Generate embeddings (legacy endpoint)."""
+        return self._proxy_request("/api/embeddings", "POST")
+
+    def embed(self) -> Response:
+        """Generate embeddings from a model."""
+        return self._proxy_request("/api/embed", "POST")
+
+    # Model management endpoints
+    def create(self) -> Response:
+        """Create a model."""
+        return self._proxy_request("/api/create", "POST", stream=True)
+
+    def show(self) -> Response:
+        """Show model information."""
+        return self._proxy_request("/api/show", "POST")
+
+    def copy(self) -> Response:
+        """Copy a model."""
+        return self._proxy_request("/api/copy", "POST")
+
+    def delete(self) -> Response:
+        """Delete a model."""
+        return self._proxy_request("/api/delete", "DELETE")
+
+    def pull(self) -> Response:
+        """Pull a model from the Ollama library."""
+        return self._proxy_request("/api/pull", "POST", stream=True)
+
+    def push(self) -> Response:
+        """Push a model to the Ollama library."""
+        return self._proxy_request("/api/push", "POST", stream=True)
+
+    # Blob management endpoints
+    def check_blob(self, digest: str) -> Response:
+        """Check if a blob exists."""
+        return self._proxy_request(f"/api/blobs/{digest}", "HEAD")
+
+    def push_blob(self, digest: str) -> Response:
+        """Push a blob to the server."""
+        return self._proxy_request(f"/api/blobs/{digest}", "POST")
+
+    # Model listing and status endpoints
+    def list_local_models(self) -> Response:
+        """List models available locally."""
         return self._proxy_request("/api/tags", "GET")
 
-    def pull(self):
-        return self._proxy_request("/api/pull", "POST", stream=True)
+    def list_running_models(self) -> Response:
+        """List models currently loaded in memory."""
+        return self._proxy_request("/api/ps", "GET")
+
+    def version(self) -> Response:
+        """Get the Ollama version."""
+        return self._proxy_request("/api/version", "GET")

--- a/services/api/src/api/ollama_routes.py
+++ b/services/api/src/api/ollama_routes.py
@@ -1,6 +1,6 @@
 import os
 
-from api.config import logger
+from api.config import BYPASS_OLLAMA_RAG, logger
 from api.middleware import require_api_key
 from api.ollama_proxy import OllamaProxy
 
@@ -10,6 +10,19 @@ class OllamaRoutes:
         self.app = app
         self.proxy = proxy
         self.register_routes()
+
+        if BYPASS_OLLAMA_RAG:
+            self.register_bypass_routes()
+
+    def register_bypass_routes(self):
+        @self.app.route("/api/chat", methods=["POST"])
+        @require_api_key
+        def chat():
+            try:
+                return self.proxy.chat()
+            except Exception as e:
+                logger.error(f"Error in chat endpoint: {e}")
+                return {"error": str(e)}, 500
 
     def register_routes(self):
         # Generation endpoints

--- a/services/api/src/api/ollama_routes.py
+++ b/services/api/src/api/ollama_routes.py
@@ -12,6 +12,7 @@ class OllamaRoutes:
         self.register_routes()
 
     def register_routes(self):
+        # Generation endpoints
         @self.app.route("/api/generate", methods=["POST"])
         @require_api_key
         def generate():
@@ -21,13 +22,59 @@ class OllamaRoutes:
                 logger.error(f"Error in generate endpoint: {e}")
                 return {"error": str(e)}, 500
 
-        @self.app.route("/api/tags", methods=["GET"])
+        @self.app.route("/api/embeddings", methods=["POST"])
         @require_api_key
-        def tags():
+        def embeddings():
             try:
-                return self.proxy.tags()
+                return self.proxy.embeddings()
             except Exception as e:
-                logger.error(f"Error in tags endpoint: {e}")
+                logger.error(f"Error in embeddings endpoint: {e}")
+                return {"error": str(e)}, 500
+
+        @self.app.route("/api/embed", methods=["POST"])
+        @require_api_key
+        def embed():
+            try:
+                return self.proxy.embed()
+            except Exception as e:
+                logger.error(f"Error in embed endpoint: {e}")
+                return {"error": str(e)}, 500
+
+        # Model management endpoints
+        @self.app.route("/api/create", methods=["POST"])
+        @require_api_key
+        def create():
+            try:
+                return self.proxy.create()
+            except Exception as e:
+                logger.error(f"Error in create endpoint: {e}")
+                return {"error": str(e)}, 500
+
+        @self.app.route("/api/show", methods=["POST"])
+        @require_api_key
+        def show():
+            try:
+                return self.proxy.show()
+            except Exception as e:
+                logger.error(f"Error in show endpoint: {e}")
+                return {"error": str(e)}, 500
+
+        @self.app.route("/api/copy", methods=["POST"])
+        @require_api_key
+        def copy():
+            try:
+                return self.proxy.copy()
+            except Exception as e:
+                logger.error(f"Error in copy endpoint: {e}")
+                return {"error": str(e)}, 500
+
+        @self.app.route("/api/delete", methods=["DELETE"])
+        @require_api_key
+        def delete():
+            try:
+                return self.proxy.delete()
+            except Exception as e:
+                logger.error(f"Error in delete endpoint: {e}")
                 return {"error": str(e)}, 500
 
         @self.app.route("/api/pull", methods=["POST"])
@@ -37,6 +84,62 @@ class OllamaRoutes:
                 return self.proxy.pull()
             except Exception as e:
                 logger.error(f"Error in pull endpoint: {e}")
+                return {"error": str(e)}, 500
+
+        @self.app.route("/api/push", methods=["POST"])
+        @require_api_key
+        def push():
+            try:
+                return self.proxy.push()
+            except Exception as e:
+                logger.error(f"Error in push endpoint: {e}")
+                return {"error": str(e)}, 500
+
+        # Blob management endpoints
+        @self.app.route("/api/blobs/<digest>", methods=["HEAD"])
+        @require_api_key
+        def check_blob(digest):
+            try:
+                return self.proxy.check_blob(digest)
+            except Exception as e:
+                logger.error(f"Error in check_blob endpoint: {e}")
+                return {"error": str(e)}, 500
+
+        @self.app.route("/api/blobs/<digest>", methods=["POST"])
+        @require_api_key
+        def push_blob(digest):
+            try:
+                return self.proxy.push_blob(digest)
+            except Exception as e:
+                logger.error(f"Error in push_blob endpoint: {e}")
+                return {"error": str(e)}, 500
+
+        # Model listing and status endpoints
+        @self.app.route("/api/tags", methods=["GET"])
+        @require_api_key
+        def list_local_models():
+            try:
+                return self.proxy.list_local_models()
+            except Exception as e:
+                logger.error(f"Error in list_local_models endpoint: {e}")
+                return {"error": str(e)}, 500
+
+        @self.app.route("/api/ps", methods=["GET"])
+        @require_api_key
+        def list_running_models():
+            try:
+                return self.proxy.list_running_models()
+            except Exception as e:
+                logger.error(f"Error in list_running_models endpoint: {e}")
+                return {"error": str(e)}, 500
+
+        @self.app.route("/api/version", methods=["GET"])
+        @require_api_key
+        def version():
+            try:
+                return self.proxy.version()
+            except Exception as e:
+                logger.error(f"Error in version endpoint: {e}")
                 return {"error": str(e)}, 500
 
 

--- a/services/api/src/api/ollama_routes.py
+++ b/services/api/src/api/ollama_routes.py
@@ -156,9 +156,9 @@ class OllamaRoutes:
                 return {"error": str(e)}, 500
 
 
-def setup_ollama_routes(app):
+def setup_ollama_proxy_routes(app):
     ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434")
     proxy = OllamaProxy(ollama_url)
     OllamaRoutes(app, proxy)
-    logger.info(f"Initialized Ollama routes with URL: {ollama_url}")
+    logger.info(f"Initialized Ollama proxy routes with Ollama URL: {ollama_url}")
     return proxy

--- a/services/api/src/api/routes.py
+++ b/services/api/src/api/routes.py
@@ -50,7 +50,7 @@ def log_request_info(request):
     logger.info("Request: %s", json.dumps(request_info, indent=None, sort_keys=True))
 
 
-def register_chat_routes(app: Flask):
+def register_rag_chat_route(app: Flask):
     @app.route("/api/chat", methods=["POST"])
     @require_api_key
     def chat():

--- a/services/api/src/api/routes.py
+++ b/services/api/src/api/routes.py
@@ -82,8 +82,8 @@ def register_chat_routes(app: Flask):
                     or "content" not in message
                 ):
                     abort(400, description="Invalid message format")
-                if message["role"] not in ["system", "user", "assistant", "tool"]:
                     abort(400, description="Invalid message role")
+                if message["role"] != "" and message["role"] not in ["system", "user", "assistant", "tool"]:
 
             # Optional parameters
             # tools = data.get("tools", [])

--- a/services/api/src/api/routes.py
+++ b/services/api/src/api/routes.py
@@ -82,8 +82,13 @@ def register_chat_routes(app: Flask):
                     or "content" not in message
                 ):
                     abort(400, description="Invalid message format")
+                if message["role"] != "" and message["role"] not in [
+                    "system",
+                    "user",
+                    "assistant",
+                    "tool",
+                ]:
                     abort(400, description="Invalid message role")
-                if message["role"] != "" and message["role"] not in ["system", "user", "assistant", "tool"]:
 
             # Optional parameters
             # tools = data.get("tools", [])

--- a/services/api/src/api/routes_setup.py
+++ b/services/api/src/api/routes_setup.py
@@ -1,4 +1,4 @@
-from api.config import PROVIDER_IS_OLLAMA, logger
+from api.config import PROVIDER_IS_OLLAMA, ENABLE_OLLAMA_PROXY, logger
 from api.ollama_routes import setup_ollama_routes
 from api.routes import register_chat_routes, register_health_routes
 from flask import Flask
@@ -6,7 +6,7 @@ from flask import Flask
 
 def setup_all_routes(app: Flask):
     try:
-        if PROVIDER_IS_OLLAMA:
+        if PROVIDER_IS_OLLAMA and ENABLE_OLLAMA_PROXY:
             # Setup Ollama-specific routes
             setup_ollama_routes(app)
             logger.info("Ollama routes registered successfully")

--- a/services/api/src/api/routes_setup.py
+++ b/services/api/src/api/routes_setup.py
@@ -1,4 +1,9 @@
-from api.config import ENABLE_OLLAMA_PROXY, PROVIDER_IS_OLLAMA, logger
+from api.config import (
+    BYPASS_OLLAMA_RAG,
+    ENABLE_OLLAMA_PROXY,
+    PROVIDER_IS_OLLAMA,
+    logger,
+)
 from api.ollama_routes import setup_ollama_routes
 from api.routes import register_chat_routes, register_health_routes
 from flask import Flask
@@ -9,11 +14,18 @@ def setup_all_routes(app: Flask):
         if PROVIDER_IS_OLLAMA and ENABLE_OLLAMA_PROXY:
             # Setup Ollama-specific routes
             setup_ollama_routes(app)
-            logger.info("Ollama routes registered successfully")
+            logger.info("Ollama proxy routes registered successfully")
 
-        # Setup chat routes (chat, streaming, etc)
-        register_chat_routes(app)
-        logger.info("Chat routes registered successfully")
+        # Setup chat routes (chat, streaming, etc.)
+        if not BYPASS_OLLAMA_RAG:
+            register_chat_routes(app)
+            logger.info(
+                "Chat routes registered successfully: RAG and embedding enabled."
+            )
+        else:
+            logger.warning(
+                "Chat routes bypassed! RAG is disabled, and embeddings will not be used."
+            )
 
         # Setup health check and basic routes
         register_health_routes(app)

--- a/services/api/src/api/routes_setup.py
+++ b/services/api/src/api/routes_setup.py
@@ -4,21 +4,21 @@ from api.config import (
     PROVIDER_IS_OLLAMA,
     logger,
 )
-from api.ollama_routes import setup_ollama_routes
-from api.routes import register_chat_routes, register_health_routes
+from api.ollama_routes import setup_ollama_proxy_routes
+from api.routes import register_health_routes, register_rag_chat_route
 from flask import Flask
 
 
 def setup_all_routes(app: Flask):
     try:
         if PROVIDER_IS_OLLAMA and ENABLE_OLLAMA_PROXY:
-            # Setup Ollama-specific routes
-            setup_ollama_routes(app)
+            # Setup Ollama proxy routes
+            setup_ollama_proxy_routes(app)
             logger.info("Ollama proxy routes registered successfully")
 
-        # Setup chat routes (chat, streaming, etc.)
-        if not BYPASS_OLLAMA_RAG:
-            register_chat_routes(app)
+        # Setup internal RAG pipeline routes
+        if not BYPASS_OLLAMA_RAG or not PROVIDER_IS_OLLAMA:
+            register_rag_chat_route(app)
             logger.info(
                 "Chat routes registered successfully: RAG and embedding enabled."
             )
@@ -27,7 +27,7 @@ def setup_all_routes(app: Flask):
                 "Chat routes bypassed! RAG is disabled, and embeddings will not be used."
             )
 
-        # Setup health check and basic routes
+        # Setup health check routes
         register_health_routes(app)
         logger.info("Health check routes registered successfully")
 

--- a/services/api/src/api/routes_setup.py
+++ b/services/api/src/api/routes_setup.py
@@ -1,4 +1,4 @@
-from api.config import PROVIDER_IS_OLLAMA, ENABLE_OLLAMA_PROXY, logger
+from api.config import ENABLE_OLLAMA_PROXY, PROVIDER_IS_OLLAMA, logger
 from api.ollama_routes import setup_ollama_routes
 from api.routes import register_chat_routes, register_health_routes
 from flask import Flask

--- a/services/api/src/core/rag_pipeline.py
+++ b/services/api/src/core/rag_pipeline.py
@@ -180,8 +180,10 @@ class RAGQueryPipeline:
         print_response: bool = False,
         use_embeddings: bool = True,
     ) -> Optional[dict]:
-        self.logger.info(f"\nProcessing Query: {query}")
-        self.logger.info(f"Conversation history present: {bool(conversation)}")
+        self.logger.info("Processing Query...")
+        self.logger.info(
+            f"Conversation history present: {bool(conversation)}; history length: {len(conversation)}"
+        )
 
         if not self.query_pipeline:
             self.logger.info("Query pipeline not initialized. Creating new pipeline...")
@@ -208,7 +210,8 @@ class RAGQueryPipeline:
                 self.conversation_logger.log_conversation(query, response, conversation)
 
             if print_response and response["llm"]["replies"]:
-                logging.info("Response: " + response["llm"]["replies"][0])
+                self.logger.info("Query: " + query)
+                self.logger.info("Response: " + response["llm"]["replies"][0])
 
             return response
 


### PR DESCRIPTION
This PR introduces full support for the Ollama API, enabling usage of the Ollama CLI client with the Cipper API. This implementation adds compatibility with many Ollama clients and augments them with the Haystack RAG pipeline and embeddings.  

Additionally, several quality-of-life improvements are included:  
- Cleaner and more structured log messages  
- Improved overall code organization and maintainability  
- Other minor enhancements to enhance reliability and readability  

**Usage**  
To utilize the updated functionality, set the `OLLAMA_HOST` environment variable and run the following command:  

```bash
export OLLAMA_HOST=localhost:21434
ollama run phi4
```