### PR TITLE
Potential fix for code scanning alert no. 26: DOM text reinterpreted as HTML

### DIFF
--- a/services/web/src/static/vendor/tts-sherpa-onnx/app-tts.js
+++ b/services/web/src/static/vendor/tts-sherpa-onnx/app-tts.js
@@ -7,7 +7,7 @@ const speedValue = document.getElementById('speedValue');
 const textArea = document.getElementById('text');
 const soundClips = document.getElementById('sound-clips');
 
-speedValue.innerHTML = speedInput.value;
+speedValue.textContent = speedInput.value;
 
 let index = 0;
 
@@ -36,7 +36,7 @@ Module.onRuntimeInitialized = function() {
 };
 
 speedInput.oninput = function() {
-  speedValue.innerHTML = this.value;
+  speedValue.textContent = this.value;
 };
 
 generateBtn.onclick = function() {


### PR DESCRIPTION
Potential fix for [https://github.com/TilmanGriesel/chipper/security/code-scanning/26](https://github.com/TilmanGriesel/chipper/security/code-scanning/26)

To fix the problem, we should avoid using `innerHTML` to set the content of the `speedValue` element. Instead, we should use `textContent`, which will treat the input as plain text and not interpret it as HTML. This change will prevent any potential XSS vulnerabilities.

- Replace the usage of `innerHTML` with `textContent` for the `speedValue` element.
- Ensure that the `speedInput.value` is treated as plain text and not interpreted as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
