### PR TITLE
Potential fix for code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/services/api/src/api/ollama_proxy.py
+++ b/services/api/src/api/ollama_proxy.py
@@ -61,9 +61,11 @@ class OllamaProxy:
             return self._handle_standard_response(response)
 
         except Exception as e:
-            logger.error(f"Error proxying request to Ollama: {str(e)}")
+            logger.error(f"Error proxying request to Ollama: {str(e)}", exc_info=True)
             return Response(
-                json.dumps({"error": str(e)}), status=500, mimetype="application/json"
+                json.dumps({"error": "An internal error has occurred."}),
+                status=500,
+                mimetype="application/json",
             )
 
     def _handle_streaming_response(self, response: requests.Response) -> Response:
@@ -75,8 +77,8 @@ class OllamaProxy:
                     if chunk:
                         yield chunk
             except Exception as e:
-                logger.error(f"Error streaming response: {str(e)}")
-                yield json.dumps({"error": str(e)}).encode()
+                logger.error(f"Error streaming response: {str(e)}", exc_info=True)
+                yield json.dumps({"error": "An internal error has occurred."}).encode()
 
         response_headers = {
             "Content-Type": response.headers.get("Content-Type", "application/json")


### PR DESCRIPTION
Potential fix for [https://github.com/TilmanGriesel/chipper/security/code-scanning/10](https://github.com/TilmanGriesel/chipper/security/code-scanning/10)

To fix the problem, we need to ensure that the detailed exception message is not exposed to the user. Instead, we should log the detailed exception message on the server and return a generic error message to the user. This can be achieved by modifying the `_proxy_request` and `_handle_streaming_response` methods to return a generic error message while logging the detailed exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
