### PR TITLE
Potential fix for code scanning alert no. 12: Information exposure through an exception

### DIFF
--- a/services/api/src/api/ollama_routes.py
+++ b/services/api/src/api/ollama_routes.py
@@ -33,7 +33,7 @@ class OllamaRoutes:
                 return self.proxy.generate()
             except Exception as e:
                 logger.error(f"Error in generate endpoint: {e}")
-                return {"error": str(e)}, 500
+                return {"error": "An internal error has occurred!"}, 500
 
         @self.app.route("/api/embeddings", methods=["POST"])
         @require_api_key
@@ -42,7 +42,7 @@ class OllamaRoutes:
                 return self.proxy.embeddings()
             except Exception as e:
                 logger.error(f"Error in embeddings endpoint: {e}")
-                return {"error": str(e)}, 500
+                return {"error": "An internal error has occurred!"}, 500
 
         @self.app.route("/api/embed", methods=["POST"])
         @require_api_key
@@ -51,7 +51,7 @@ class OllamaRoutes:
                 return self.proxy.embed()
             except Exception as e:
                 logger.error(f"Error in embed endpoint: {e}")
-                return {"error": str(e)}, 500
+                return {"error": "An internal error has occurred!"}, 500
 
         # Model management endpoints
         @self.app.route("/api/create", methods=["POST"])
@@ -61,7 +61,7 @@ class OllamaRoutes:
                 return self.proxy.create()
             except Exception as e:
                 logger.error(f"Error in create endpoint: {e}")
-                return {"error": str(e)}, 500
+                return {"error": "An internal error has occurred!"}, 500
 
         @self.app.route("/api/show", methods=["POST"])
         @require_api_key


### PR DESCRIPTION
Potential fix for [https://github.com/TilmanGriesel/chipper/security/code-scanning/12](https://github.com/TilmanGriesel/chipper/security/code-scanning/12)

To fix the problem, we need to ensure that the exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling blocks to return a generic error message while keeping the logging intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
