### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/services/web/src/main.py
+++ b/services/web/src/main.py
@@ -304,8 +304,15 @@ def create_app():
                 if hasattr(e, "response") and e.response is not None
                 else 500
             )
+            logger.error(f"RequestException: {str(e)}")
             return (
-                jsonify({"error": str(e), "done": True, "done_reason": "error"}),
+                jsonify(
+                    {
+                        "error": "An internal error has occurred",
+                        "done": True,
+                        "done_reason": "error",
+                    }
+                ),
                 status_code,
             )
 


### PR DESCRIPTION
Potential fix for [https://github.com/TilmanGriesel/chipper/security/code-scanning/7](https://github.com/TilmanGriesel/chipper/security/code-scanning/7)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

1. Import the `logging` module if it is not already imported.
2. Modify the exception handling block to log the detailed error message using the `logger` and return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
