### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/services/api/src/api/handlers.py
+++ b/services/api/src/api/handlers.py
@@ -278,6 +278,6 @@ def handle_standard_response(
             "created_at": datetime.now(timezone.utc).isoformat(),
             "done": True,
             "done_reason": "error",
-            "error": str(e),
+            "error": "An internal error has occurred. Please try again later.",
         }
         return jsonify(error_response)


### PR DESCRIPTION
Potential fix for [https://github.com/TilmanGriesel/chipper/security/code-scanning/6](https://github.com/TilmanGriesel/chipper/security/code-scanning/6)

To fix the problem, we need to modify the code to ensure that detailed exception information is not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by updating the `except` block to remove the detailed exception message from the `error_response`.

1. In the `handle_standard_response` function, update the `except` block to remove the detailed exception message from the `error_response`.
2. Ensure that the detailed exception information is logged on the server using the `logger.error` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
