### PR TITLE
Potential fix for code scanning alert no. 20: Information exposure through an exception

### DIFF
--- a/services/api/src/api/ollama_routes.py
+++ b/services/api/src/api/ollama_routes.py
@@ -79,7 +79,7 @@ class OllamaRoutes:
                 return self.proxy.copy()
             except Exception as e:
                 logger.error(f"Error in copy endpoint: {e}")
-                return {"error": str(e)}, 500
+                return {"error": "An internal error has occurred!"}, 500
 
         @self.app.route("/api/delete", methods=["DELETE"])
         @require_api_key
@@ -88,7 +88,7 @@ class OllamaRoutes:
                 return self.proxy.delete()
             except Exception as e:
                 logger.error(f"Error in delete endpoint: {e}")
-                return {"error": str(e)}, 500
+                return {"error": "An internal error has occurred!"}, 500
 
         @self.app.route("/api/pull", methods=["POST"])
         @require_api_key
@@ -97,7 +97,7 @@ class OllamaRoutes:
                 return self.proxy.pull()
             except Exception as e:
                 logger.error(f"Error in pull endpoint: {e}")
-                return {"error": str(e)}, 500
+                return {"error": "An internal error has occurred!"}, 500
 
         @self.app.route("/api/push", methods=["POST"])
         @require_api_key
@@ -106,7 +106,7 @@ class OllamaRoutes:
                 return self.proxy.push()
             except Exception as e:
                 logger.error(f"Error in push endpoint: {e}")
-                return {"error": str(e)}, 500
+                return {"error": "An internal error has occurred!"}, 500
 
         # Blob management endpoints
         @self.app.route("/api/blobs/<digest>", methods=["HEAD"])


### PR DESCRIPTION
Potential fix for [https://github.com/TilmanGriesel/chipper/security/code-scanning/20](https://github.com/TilmanGriesel/chipper/security/code-scanning/20)

To fix the problem, we need to ensure that the exception messages returned to the user do not contain sensitive information. Instead, we should return a generic error message while logging the detailed exception message on the server for debugging purposes. This approach maintains the application's security while still providing developers with the necessary information to diagnose issues.

We will update the exception handling in the `copy`, `delete`, `pull`, and `push` methods to return a generic error message instead of the exception message. The `check_blob`, `push_blob`, `list_local_models`, `list_running_models`, and `version` methods already follow this practice, so no changes are needed for them.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
