### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/services/web/src/main.py
+++ b/services/web/src/main.py
@@ -326,8 +326,8 @@ def create_app():
             session_manager.abort_chat(session_id)
             return jsonify({"status": "success", "message": "Chat aborted"})
         except Exception as e:
-            logger.error(f"Error aborting chat: {str(e)}")
-            return jsonify({"error": str(e)}), 500
+            logger.error(f"Error aborting chat: {str(e)}", exc_info=True)
+            return jsonify({"error": "An internal error has occurred"}), 500
 
     @app.route("/")
     def index():


### PR DESCRIPTION
Potential fix for [https://github.com/TilmanGriesel/chipper/security/code-scanning/8](https://github.com/TilmanGriesel/chipper/security/code-scanning/8)

To fix the problem, we should avoid returning the raw exception message to the user. Instead, we should log the detailed exception message on the server and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

- Modify the exception handling in the `abort_chat` function to log the detailed exception message and return a generic error message to the user.
- Ensure that the logging captures enough information for debugging purposes without exposing sensitive data to the end user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
