### PR TITLE
Potential fix for code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/services/web/src/main.py
+++ b/services/web/src/main.py
@@ -61,7 +61,7 @@ def get_api_health() -> Dict[str, Any]:
         return response.json()
     except Exception as e:
         logger.error(f"API health check failed: {str(e)}")
-        return {"status": "unhealthy", "error": str(e)}
+        return {"status": "unhealthy", "error": "An internal error has occurred."}
 
 
 class SessionManager:


### PR DESCRIPTION
Potential fix for [https://github.com/TilmanGriesel/chipper/security/code-scanning/9](https://github.com/TilmanGriesel/chipper/security/code-scanning/9)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to external users. Instead, we should log the detailed error message on the server and return a generic error message to the client. This can be achieved by modifying the `get_api_health` function to return a generic error message when an exception occurs.

- Modify the `get_api_health` function to log the detailed error message and return a generic error message in the response.
- Ensure that the `/health` endpoint returns a response with a generic error message when the API health check fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
