### PR TITLE
fix: Unvalidated dynamic method call

### DIFF
--- a/services/web/src/static/js/chatCommandHandler.js
+++ b/services/web/src/static/js/chatCommandHandler.js
@@ -83,8 +83,12 @@ export class ChatCommandHandler {
       },
     };
 
-    const command = commands[parts[0]];
-    return command ? command() : null;
+    const commandKey = parts[0];
+    if (commands.hasOwnProperty(commandKey) && typeof commands[commandKey] === "function") {
+      return commands[commandKey]();
+    } else {
+      return null;
+    }
   }
 
   getHelpMessage() {


### PR DESCRIPTION
Potential fix for [https://github.com/TilmanGriesel/chipper/security/code-scanning/30](https://github.com/TilmanGriesel/chipper/security/code-scanning/30)

To fix the problem, we need to validate that the `command` exists in the `commands` object and is a function before attempting to call it. This can be achieved by using the `hasOwnProperty` method to check if the command is a valid key in the `commands` object and then verifying that the value is a function.
